### PR TITLE
Add constants and improve update_state_data

### DIFF
--- a/elro/__init__.py
+++ b/elro/__init__.py
@@ -1,3 +1,3 @@
 """Elro connects P1 API."""
 
-__version__ = "0.1.1-4"
+__version__ = "0.1.2"

--- a/elro/device.py
+++ b/elro/device.py
@@ -49,6 +49,19 @@ class DeviceType(Enum):
         )
 
 
+# Represent alarm device types
+ALARM_CO = "CO_ALARM"
+ALARM_FIRE = "FIRE_ALARM"
+ALARM_HEAT = "HEAT_ALARM"
+ALARM_SMOKE = "SMOKE_ALARM"
+ALARM_WATER = "WATER_ALARM"
+
+# Represent device state attributes
+ATTR_BATTERY_LEVEL = "battery"
+ATTR_DEVICE_TYPE = "device_type"
+ATTR_DEVICE_STATE = "device_state"
+ATTR_SIGNAL = "signal"
+
 # Represent the state of a device.
 DEVICE_STATE = {
     "12": "FAULT",
@@ -62,3 +75,15 @@ DEVICE_STATE = {
     "FE": "UNKNOWN",
     "FF": "OFFLINE",
 }
+
+STATE_ALARM = "ALARM"
+STATE_FAULT = "FAULT"
+STATE_FIRE_ALARM = "FIRE ALARM"
+STATE_NORMAL = "NORMAL"
+STATE_OFFLINE = "OFFLINE"
+STATE_SILENCE = "SILENCE"
+STATE_TEST_ALARM = "TEST ALARM"
+STATE_UNKNOWN = "UNKNOWN"
+
+STATES_ON = (STATE_ALARM, STATE_FIRE_ALARM, STATE_TEST_ALARM)
+STATES_OFFLINE = (STATE_OFFLINE,)

--- a/elro/utils.py
+++ b/elro/utils.py
@@ -244,7 +244,10 @@ def update_state_data(
     if data_update is None or data is None:
         return
     for key in data_update.keys():
-        data[key].update(data_update[key])
+        if not key in data:
+            data[key] = data_update[key]
+        else:
+            data[key].update(data_update[key])
 
 
 def get_device_names(content: list) -> dict:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -77,7 +77,7 @@ def help_mock_command_reply(mock_k1_connector, response):
     """Mock sendto and send a reply from mock_replies."""
     req = 0
 
-    def sendto(data):
+    def sendto(data):  # pylint disable=unused-argument
         """Mock a reply."""
         nonlocal req
         if req >= len(response):


### PR DESCRIPTION
Adds constants to elro.device for device types, attributes and states.
Improves update_state_data to initialize if a dict has not been setup yet.