### PR TITLE
Adjust Lock to catch intermediate disconnect

### DIFF
--- a/elro/__init__.py
+++ b/elro/__init__.py
@@ -1,3 +1,3 @@
 """Elro connects P1 API."""
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"

--- a/elro/api.py
+++ b/elro/api.py
@@ -189,6 +189,7 @@ class K1:
         **argv: int | str,
     ) -> dict[int, dict[str, Any]] | None:
         """Get device names."""
+        await self._lock.acquire()
         iteration = 0
         if (
             not self._protocol
@@ -196,6 +197,7 @@ class K1:
             or not self._loop
             or not self._session
         ):
+            self._lock.release()
             raise K1.K1ConnectionError("Not connected to a K1 hub.")
 
         if attributes["attribute_transformer"]:
@@ -208,7 +210,6 @@ class K1:
             command_data.update(cast(Mapping[str, Any], argv))
         command = self._prepare_command(command_data)
         contentlist = []
-        await self._lock.acquire()
         try:
             self._protocol.datagram_data = self._loop.create_future()
             self._transport.sendto(command)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = lib-elro-connects
 author = Jan Bouwhuis, Bas van den Berg, Johannes Kulick
-version = 0.4.0
+version = 0.4.1
 description = Provides an API to the Elro Connects K1 Connector
 long_description = file: README.md, LICENSE
 license = MIT License


### PR DESCRIPTION
When processing a command the connection status should be checked. The command should be aborted if the connector is disconnected.