### PR TITLE
Filter illegal device states add water test alarm - bump to v0.4.3

### DIFF
--- a/elro/__init__.py
+++ b/elro/__init__.py
@@ -1,3 +1,3 @@
 """Elro connects P1 API."""
 
-__version__ = "0.4.2"
+__version__ = "0.4.3"

--- a/elro/command.py
+++ b/elro/command.py
@@ -134,6 +134,16 @@ TEST_ALARM = CommandAttributes(
     content_sync_finished=2,
     content_transformer=None,
 )
+# TEST_ALARM for water detector
+TEST_ALARM_WATER = CommandAttributes(
+    cmd_id=Command.EQUIPMENT_CONTROL,
+    attribute_transformer=None,
+    additional_attributes={"device_ID": 0, "device_status": "BB000000"},
+    receive_types=[Command.ANSWER_YES_OR_NO],
+    content_field="answer_yes_or_no",
+    content_sync_finished=2,
+    content_transformer=None,
+)
 
 SILENCE_ALARM = CommandAttributes(
     cmd_id=Command.EQUIPMENT_CONTROL,

--- a/elro/utils.py
+++ b/elro/utils.py
@@ -273,17 +273,21 @@ def set_device_name(argv: dict) -> None:
 
 def get_device_states(content: list) -> dict:
     """Return device states."""
-
-    return {
-        hexdata["device_ID"]: {
-            "device_type": DeviceType(hexdata["device_name"]).name,
+    hexdata = {}
+    for hexdata in content:
+        try:
+            device_type = DeviceType(hexdata["device_name"]).name
+        except ValueError:
+            # Unsupported record, skip and continue silently
+            continue
+        hexdata["device_ID"] = {
+            "device_type": device_type,
             "signal": int(hexdata["device_status"][0:2], 16),
             "battery": int(hexdata["device_status"][2:4], 16),
             "device_state": DEVICE_STATE.get(hexdata["device_status"][4:6], "n/a"),
             "device_status_data": hexdata,
         }
-        for hexdata in content
-    }
+    return hexdata
 
 
 def get_default(content: list) -> dict:

--- a/examples/fire_alarm_demo.py
+++ b/examples/fire_alarm_demo.py
@@ -91,7 +91,8 @@ class AlarmDemo(K1):
                 await self.async_disconnect()
 
         # Test alarm (assuming there are 3 fire alarms)
-        # Be aware they cannot be fired alle together, silence an alarm befor testing the next alarm.
+        # Be aware they cannot be fired alle together, silence an alarm before testing the next alarm.
+        # Use TEST_ALARM_WATER for water detectors
         await self.async_connect()
         print("Test alarm 1")
         await self.async_process_command(TEST_ALARM, device_ID=1)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = lib-elro-connects
 author = Jan Bouwhuis, Bas van den Berg, Johannes Kulick
-version = 0.4.2
+version = 0.4.3
 description = Provides an API to the Elro Connects K1 Connector
 long_description = file: README.md, LICENSE
 license = MIT License


### PR DESCRIPTION
Add the following functions:
- New `TEST_ALARM_WATER` command to test water detectors.
- Filter not supported device types.