### PR TITLE
Support config API key

### DIFF
--- a/elro/__init__.py
+++ b/elro/__init__.py
@@ -1,3 +1,3 @@
 """Elro connects P1 API."""
 
-__version__ = "0.5.1"
+__version__ = "0.5.2"

--- a/elro/api.py
+++ b/elro/api.py
@@ -156,7 +156,9 @@ class K1:
         finally:
             self._lock.release()
 
-    async def async_configure(self, ipaddress: str, port: int = 1025) -> None:
+    async def async_configure(
+        self, ipaddress: str, port: int = 1025, api_key: str | None = None
+    ) -> None:
         """Process updated settings."""
         try:
             await self._lock.acquire()
@@ -166,6 +168,7 @@ class K1:
             self._transport = None
             self._protocol = None
             self._session = {}
+            self._api_key = api_key
             self._remoteaddress = (ipaddress, port)
             self._lock.release()
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = lib-elro-connects
 author = Jan Bouwhuis, Bas van den Berg, Johannes Kulick
-version = 0.5.1
+version = 0.5.2
 description = Provides an API to the Elro Connects K1 Connector
 long_description = file: README.md, LICENSE
 license = MIT License

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -21,7 +21,7 @@ MOCK_AUTH_RESPONSE = {
 MOCK_DEVICE_RESPONSE = [
     {
         "ctrlKey": "deadbeefdeadbeefdeadbeefdeadbeef",
-        "devTid": "ST_84f3eb1a0021",
+        "devTid": "ST_deadbeef0000",
         "devType": "INDEPENDENT",
         "mid": "0123456789ab",
         "bindKey": "beefdead012345678beefdead0123456",


### PR DESCRIPTION
Enables updating the `api_key` using `async_update_settings` after the configuration has changed.