### PR TITLE
Add device state 22 as FIRE ALARM

### DIFF
--- a/elro/__init__.py
+++ b/elro/__init__.py
@@ -1,3 +1,3 @@
 """Elro connects P1 API."""
 
-__version__ = "0.5.2"
+__version__ = "0.5.3"

--- a/elro/device.py
+++ b/elro/device.py
@@ -68,6 +68,7 @@ DEVICE_STATE = {
     "15": "SILENCE",
     "17": "TEST ALARM",
     "19": "FIRE ALARM",
+    "22": "FIRE ALARM",
     "1B": "SILENCE",
     "BB": "TEST ALARM",
     "55": "ALARM",  # OPEN window sensor

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = lib-elro-connects
 author = Jan Bouwhuis, Bas van den Berg, Johannes Kulick
-version = 0.5.2
+version = 0.5.3
 description = Provides an API to the Elro Connects K1 Connector
 long_description = file: README.md, LICENSE
 license = MIT License


### PR DESCRIPTION
Add previously unknown device_state `22` as `FIRE ALARM`.
Fixes: https://github.com/jbouwh/ha-elro-connects/issues/5