### PR TITLE
Domain handling

### DIFF
--- a/elro/auth.py
+++ b/elro/auth.py
@@ -113,6 +113,7 @@ class ElroConnectsSession:
             return ""
 
         if not self._domain.startswith("hekr"): # default
+            self._domain = None
             return "hekr.me"
 
         return self._domain


### PR DESCRIPTION
This update properly retrieves the domain for the API. That domain is where the data is stored for the user. With this, Asian and American users can now use this package. Though i don't think ELRO is being sold there, it opens the possibilities to easier integrate other PID's. If there is an error within the JSON, it is not handled properly because i don't know which error to throw there...