### PR TITLE
Handle door or window state 66 as normal

### DIFF
--- a/elro/device.py
+++ b/elro/device.py
@@ -69,6 +69,7 @@ DEVICE_STATE = {
     "17": "TEST ALARM",
     "19": "FIRE ALARM",
     "22": "FIRE ALARM",
+    "66": "NORMAL",
     "1B": "SILENCE",
     "BB": "TEST ALARM",
     "55": "ALARM",  # OPEN window sensor


### PR DESCRIPTION
Adds device-state `66` as normal.
