### PR TITLE
Limit hex command length to 8 positions

### DIFF
--- a/elro/__init__.py
+++ b/elro/__init__.py
@@ -1,3 +1,3 @@
 """Elro connects P1 API."""
 
-__version__ = "0.5.5.2"
+__version__ = "0.5.5.3"

--- a/examples/socket_demo.py
+++ b/examples/socket_demo.py
@@ -48,7 +48,7 @@ class SocketDemo(K1):
             attribute_transformer=None,
             additional_attributes={
                 "device_ID": 0,
-                "device_status": f"{command_code_hex}000000",
+                "device_status": f"{command_code_hex}00000000"[:8],
             },
             receive_types=[Command.ANSWER_YES_OR_NO],
             content_field="answer_yes_or_no",


### PR DESCRIPTION
When testing socket commands we should pass 8 positions to the K1 connector